### PR TITLE
Re-sign assemblies after fixing references

### DIFF
--- a/src/Brutal.Dev.StrongNameSigner.Console/Program.cs
+++ b/src/Brutal.Dev.StrongNameSigner.Console/Program.cs
@@ -104,7 +104,7 @@ namespace Brutal.Dev.StrongNameSigner.Console
         // Go through all the references excluding the file we are working on.
         foreach (var referencePath in referencesToFix.Where(r => !r.Equals(filePath)))
         {
-          if (FixSingleAssemblyReference(filePath, referencePath))
+          if (FixSingleAssemblyReference(filePath, referencePath, options.KeyFile, options.Password))
           {
             referenceFixes++;
           }
@@ -157,7 +157,7 @@ namespace Brutal.Dev.StrongNameSigner.Console
       return null;
     }
 
-    private static bool FixSingleAssemblyReference(string assemblyPath, string referencePath)
+    private static bool FixSingleAssemblyReference(string assemblyPath, string referencePath, string keyFile, string keyFilePassword)
     {
       try
       {
@@ -165,7 +165,7 @@ namespace Brutal.Dev.StrongNameSigner.Console
         C.WriteLine("Fixing references to '{1}' in '{0}'...", assemblyPath, referencePath);
 
         var info = SigningHelper.GetAssemblyInfo(assemblyPath);
-        if (SigningHelper.FixAssemblyReference(assemblyPath, referencePath))
+        if (SigningHelper.FixAssemblyReference(assemblyPath, referencePath, keyFile, keyFilePassword))
         {
           C.ForegroundColor = ConsoleColor.Green;
           C.WriteLine("References were fixed successfully!");

--- a/src/Brutal.Dev.StrongNameSigner.UI/MainForm.cs
+++ b/src/Brutal.Dev.StrongNameSigner.UI/MainForm.cs
@@ -416,7 +416,7 @@ namespace Brutal.Dev.StrongNameSigner.UI
             }
 
             log.AppendFormat("Fixing references to {1} in {0}...", filePath, reference).AppendLine();
-            if (SigningHelper.FixAssemblyReference(filePath, reference))
+            if (SigningHelper.FixAssemblyReference(filePath, reference, keyFile, password))
             {
               log.Append("Reference was found and fixed.").AppendLine();
               referenceFixes++;

--- a/src/Brutal.Dev.StrongNameSigner/SigningHelper.cs
+++ b/src/Brutal.Dev.StrongNameSigner/SigningHelper.cs
@@ -209,7 +209,7 @@ namespace Brutal.Dev.StrongNameSigner
     /// or
     /// Could not find provided reference assembly file.
     /// </exception>
-    public static bool FixAssemblyReference(string assemblyPath, string referenceAssemblyPath)
+    public static bool FixAssemblyReference(string assemblyPath, string referenceAssemblyPath, string keyPath = null, string keyFilePassword = null)
     {
       // Verify assembly path was passed in.
       if (string.IsNullOrWhiteSpace(assemblyPath))
@@ -246,8 +246,14 @@ namespace Brutal.Dev.StrongNameSigner
         {
           assemblyReference.PublicKeyToken = b.Name.PublicKeyToken ?? new byte[0];
 
-          a.Write(assemblyPath);
-
+          if (!String.IsNullOrEmpty(keyPath))
+          {
+            a.Write(assemblyPath, new WriterParameters { StrongNameKeyPair = GetStrongNameKeyPair(keyPath, keyFilePassword) });
+          }
+          else 
+          {
+            a.Write(assemblyPath);
+          }
           fixApplied = true;
         }
       }


### PR DESCRIPTION
Added re-signing to the reference fixing code and called it from the Console App and UI.

This should address #8 and #9.