### PR TITLE
Added some fixes to version 2.7.0 to further improve performance

### DIFF
--- a/src/Brutal.Dev.StrongNameSigner/AutomaticBuildTask.cs
+++ b/src/Brutal.Dev.StrongNameSigner/AutomaticBuildTask.cs
@@ -70,8 +70,9 @@ namespace Brutal.Dev.StrongNameSigner
         {
           var ret = new TaskItem(References[i]);
 
-          if (References[i].ItemSpec.IndexOf("netstandard.library", StringComparison.OrdinalIgnoreCase) > -1 &&
-              References[i].ItemSpec.IndexOf("\\dotnet\\sdk\\", StringComparison.OrdinalIgnoreCase) > -1)
+          if ((References[i].ItemSpec.IndexOf("netstandard.library", StringComparison.OrdinalIgnoreCase) > -1 &&
+               References[i].ItemSpec.IndexOf("\\dotnet\\sdk\\", StringComparison.OrdinalIgnoreCase) > -1) ||
+              (References[i].ItemSpec.IndexOf(@"\Reference Assemblies\Microsoft\Framework\", StringComparison.OrdinalIgnoreCase) > -1))
           {
             ret.ItemSpec = References[i].ItemSpec;
             SignedAssembliesToReference[i] = ret;

--- a/src/Brutal.Dev.StrongNameSigner/AutomaticBuildTask.cs
+++ b/src/Brutal.Dev.StrongNameSigner/AutomaticBuildTask.cs
@@ -91,17 +91,17 @@ namespace Brutal.Dev.StrongNameSigner
             {
               signedAssembly = SignSingleAssembly(References[i].ItemSpec, snkFilePath, signedAssemblyFolder, probingPaths);
               chagesMade = true;
-            }
-
-            if (signedAssembly.IsSigned)
-            {
-              signedAssemblyPaths.Add(signedAssembly.FilePath);
-              processedAssemblyPaths.Add(signedAssembly.FilePath);
-              ret.ItemSpec = signedAssembly.FilePath;
-            }
-            else
-            {
-              processedAssemblyPaths.Add(References[i].ItemSpec);
+              
+              if (signedAssembly.IsSigned)
+              {
+                signedAssemblyPaths.Add(signedAssembly.FilePath);
+                processedAssemblyPaths.Add(signedAssembly.FilePath);
+                ret.ItemSpec = signedAssembly.FilePath;
+              }
+              else
+              {
+                processedAssemblyPaths.Add(References[i].ItemSpec);
+              }
             }
 
             SignedAssembliesToReference[i] = ret;


### PR DESCRIPTION
This is related to https://github.com/brutaldev/StrongNameSigner/issues/57.

Version 2.7.0 doesn't fix the issue I'm having. Checking the msbuild binary log, it seems that there is another path of Microsoft Framework assemblies that are being processed which it should not (as intended by the update done to version 2.7.0). I added the path to the exclude list.

Also I noted that assemblies that are originally signed being processed again and again by StrongNameSigner. This update removed them from being processed.