### PR TITLE
Add condition to disable automatic signing

### DIFF
--- a/src/Brutal.Dev.StrongNameSigner/StrongNameSigner.targets
+++ b/src/Brutal.Dev.StrongNameSigner/StrongNameSigner.targets
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask TaskName="Brutal.Dev.StrongNameSigner.AutomaticBuildTask" AssemblyFile="$(MSBuildThisFileDirectory)Brutal.Dev.StrongNameSigner.dll" />
 
-  <Target Name="StrongNameSignerTarget" AfterTargets="AfterResolveReferences">
+  <Target Name="StrongNameSignerTarget" AfterTargets="AfterResolveReferences" Condition="$(EnableStrongNameSigner) != 'false'">
     <Brutal.Dev.StrongNameSigner.AutomaticBuildTask References="@(ReferencePath)" CopyLocalPaths="@(ReferenceCopyLocalPaths)" OutputPath="$(IntermediateOutputPath)" KeyFile="$(StrongNameKeyFile)" Password="$(StrongNamePassword)">
       <Output TaskParameter="SignedAssembliesToReference" ItemName="AssembliesToReference" />
       <Output TaskParameter="NewCopyLocalFiles" ItemName="NewCopyLocalFiles" />
@@ -20,5 +20,6 @@
     <ResolveReferencesDependsOn>$(ResolveReferencesDependsOn);StrongNameSignerTarget</ResolveReferencesDependsOn>
     <!-- Declare a variable that contains the path to the StrongNameSigner directory for pre and post build steps with the following syntax: $(StrongNameSignerDirectory) -->
     <StrongNameSignerDirectory>$(MSBuildThisFileDirectory)</StrongNameSignerDirectory>
+    <EnableStrongNameSigner Condition="'$(EnableStrongNameSigner)' == ''">true</EnableStrongNameSigner>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
# Description

Adds optional parameter to allow developers to disable the Automatic Signing Target while still getting the location for the Strong Name Signer console app. This makes it easier if someone is trying to customize the signing process.