### PR TITLE
Provide KeyFile & Password parameters

### DIFF
--- a/src/Brutal.Dev.StrongNameSigner/AutomaticBuildTask.cs
+++ b/src/Brutal.Dev.StrongNameSigner/AutomaticBuildTask.cs
@@ -18,6 +18,10 @@ namespace Brutal.Dev.StrongNameSigner
 
     public ITaskItem[] CopyLocalPaths { get; set; }
 
+    public string KeyFile { get; set; }
+
+    public string Password { get; set; }
+
     [Output]
     public ITaskItem[] SignedAssembliesToReference { get; set; }
 
@@ -42,6 +46,12 @@ namespace Brutal.Dev.StrongNameSigner
         if (OutputPath == null || string.IsNullOrEmpty(OutputPath.ItemSpec))
         {
           Log.LogError("Task parameter 'OutputPath' not provided.");
+          return false;
+        }
+
+        if (!string.IsNullOrEmpty(KeyFile) && !File.Exists(KeyFile))
+        {
+          Log.LogError($"The Key File '{KeyFile}' does not exist.");
           return false;
         }
 
@@ -84,7 +94,7 @@ namespace Brutal.Dev.StrongNameSigner
           }
         }
 
-        SigningHelper.SignAssemblies(assembliesToSign, string.Empty, string.Empty, probingPaths);
+        SigningHelper.SignAssemblies(assembliesToSign, KeyFile, Password, probingPaths);
 
         if (CopyLocalPaths != null)
         {

--- a/src/Brutal.Dev.StrongNameSigner/StrongNameSigner.targets
+++ b/src/Brutal.Dev.StrongNameSigner/StrongNameSigner.targets
@@ -3,7 +3,7 @@
   <UsingTask TaskName="Brutal.Dev.StrongNameSigner.AutomaticBuildTask" AssemblyFile="$(MSBuildThisFileDirectory)Brutal.Dev.StrongNameSigner.dll" />
 
   <Target Name="StrongNameSignerTarget" AfterTargets="AfterResolveReferences">
-    <Brutal.Dev.StrongNameSigner.AutomaticBuildTask References="@(ReferencePath)" CopyLocalPaths="@(ReferenceCopyLocalPaths)" OutputPath="$(IntermediateOutputPath)">
+    <Brutal.Dev.StrongNameSigner.AutomaticBuildTask References="@(ReferencePath)" CopyLocalPaths="@(ReferenceCopyLocalPaths)" OutputPath="$(IntermediateOutputPath)" KeyFile="$(StrongNameKeyFile)" Password="$(StrongNamePassword)">
       <Output TaskParameter="SignedAssembliesToReference" ItemName="AssembliesToReference" />
       <Output TaskParameter="NewCopyLocalFiles" ItemName="NewCopyLocalFiles" />
     </Brutal.Dev.StrongNameSigner.AutomaticBuildTask>


### PR DESCRIPTION
# Description

Add optional KeyFile and Password parameters so that developers can provide a key file to be used when signing the assemblies. This is critical for scenarios where the developer must know what the public key is for the signed assemblies in manifests such as Visual Studio Templates