### PR TITLE
Fix temp directory access when signing in parallel

### DIFF
--- a/src/Brutal.Dev.StrongNameSigner.Tests/SignAssemblyTests.cs
+++ b/src/Brutal.Dev.StrongNameSigner.Tests/SignAssemblyTests.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography;
-using System.Threading;
 using System.Threading.Tasks;
 using Shouldly;
 using Xunit;

--- a/src/Brutal.Dev.StrongNameSigner.Tests/SignAssemblyTests.cs
+++ b/src/Brutal.Dev.StrongNameSigner.Tests/SignAssemblyTests.cs
@@ -1,6 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
 using Shouldly;
 using Xunit;
 
@@ -263,6 +266,15 @@ namespace Brutal.Dev.StrongNameSigner.Tests
       {
         Directory.Delete(tempDir, true);
       }
+    }
+
+    [Fact]
+    public void SignAssembly_InParralel_Should_Succeed()
+    {
+      Parallel.Invoke(
+        SignAssembly_Public_API_Test,
+        SignAssembly_Should_Reassemble_NET_45_Assembly_Correctly
+      );
     }
   }
 }

--- a/src/Brutal.Dev.StrongNameSigner/SigningHelper.cs
+++ b/src/Brutal.Dev.StrongNameSigner/SigningHelper.cs
@@ -203,7 +203,7 @@ namespace Brutal.Dev.StrongNameSigner
 
       // File locking issues in Mono.Cecil are a real pain in the ass so let's create a working directory of files to process, then copy them back when we're done.
       var tempFilePathToInputOutputFilePairMap = new Dictionary<string, InputOutputFilePair>();
-      var tempPath = Path.Combine(Path.GetTempPath(), "StrongNameSigner");
+      var tempPath = Path.Combine(Path.GetTempPath(), "StrongNameSigner-" + Guid.NewGuid().ToString());
       Directory.CreateDirectory(tempPath);
 
       foreach (var inputOutpuFilePair in assemblyInputOutputPaths)


### PR DESCRIPTION
If multiple signings are running at the same time, all of them would use the same temp directory name and when one finishes it [deletes the temp directory](https://github.com/brutaldev/StrongNameSigner/blob/master/src/Brutal.Dev.StrongNameSigner/SigningHelper.cs#L515) along with the files the other instances may have still wanted to use.